### PR TITLE
Save game progress

### DIFF
--- a/Assets/Scenes/MainMenu.unity
+++ b/Assets/Scenes/MainMenu.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b4212800cb1cb83c8a0ab295417d1bb987594d1b1e4eeb0d25491f877868b01a
-size 36899
+oid sha256:f58c448b6632f4df40b58b38f12cf1e8da26524cb157b1ca7d371fb319fbb48b
+size 37024

--- a/Assets/Scenes/MainMenu.unity
+++ b/Assets/Scenes/MainMenu.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f58c448b6632f4df40b58b38f12cf1e8da26524cb157b1ca7d371fb319fbb48b
-size 37024
+oid sha256:447ab011218b3c063f85f5825b4514ea1d87c6d343a65ba3c7c8949d3980ef64
+size 43137

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -45,8 +45,13 @@ public class GameManager : MonoBehaviour
 
         m_instance = this;
 
+        // TODO: load from save file if file exists
+        PlayerProgress = new SaveData();
+
         coinCollectedEvent = new CoinCollectedEvent();
         saveProgressEvent = new SaveProgressEvent();
+
+        Application.targetFrameRate = 60;
     }
 
     void Update()
@@ -83,11 +88,6 @@ public class GameManager : MonoBehaviour
 
     public void Play(LevelDescriptor level = null)
     {
-        if(PlayerProgress == null)
-        {
-            PlayerProgress = new SaveData();
-        }
-
         if(CurrentLevel != null)
         {
             saveProgressEvent.Invoke();

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -45,8 +45,8 @@ public class GameManager : MonoBehaviour
 
         m_instance = this;
 
-        // TODO: load from save file if file exists
-        PlayerProgress = new SaveData();
+        // Load from file or create new
+        PlayerProgress = SaveData.LoadSaveFile(m_saveFilename);
 
         coinCollectedEvent = new CoinCollectedEvent();
         saveProgressEvent = new SaveProgressEvent();
@@ -56,6 +56,7 @@ public class GameManager : MonoBehaviour
 
     void Update()
     {
+        // TODO: catch exception on NullPointers so that 0 levels played doesnt mean no save data
         // try{
         //     string saveData = PlayerProgress.ToString();
         //     Debug.Log(saveData);
@@ -80,18 +81,35 @@ public class GameManager : MonoBehaviour
     private string m_levelsScene;
     public string LevelsScene { get { return m_levelsScene; } }
 
+    // ================== SAVE DATA ================================
+
     // Stores the players progess
     public SaveData PlayerProgress { get; private set; }
     public SaveProgressEvent saveProgressEvent;
+
+    // Currently only supports one player profile
+    private const string m_saveFilename = "savegame.trololo";
+
+    private void SavePlayerProgress()
+    {
+        if(CurrentLevel != null)
+        {
+            saveProgressEvent.Invoke();
+            PlayerProgress.SaveToFile(m_saveFilename);
+        }
+    }
+
+    public void ResetSaveData()
+    {
+        PlayerProgress = new SaveData();
+        PlayerProgress.SaveToFile(m_saveFilename);
+    }
 
     // ================== SCENE SWITCHING ========================
 
     public void Play(LevelDescriptor level = null)
     {
-        if(CurrentLevel != null)
-        {
-            saveProgressEvent.Invoke();
-        }
+        SavePlayerProgress();
 
         if(level == null)
         {
@@ -131,10 +149,7 @@ public class GameManager : MonoBehaviour
 
     public void LevelSelect()
     {
-        if(CurrentLevel != null)
-        {
-            saveProgressEvent.Invoke();
-        }
+        SavePlayerProgress();
 
         CurrentLevel = null;
 
@@ -143,10 +158,7 @@ public class GameManager : MonoBehaviour
 
     public void ExitToMenu()
     {
-        if(CurrentLevel != null)
-        {
-            saveProgressEvent.Invoke();
-        }
+        SavePlayerProgress();
 
         CurrentLevel = null;
 

--- a/Assets/Scripts/SaveData.cs
+++ b/Assets/Scripts/SaveData.cs
@@ -1,5 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
+using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
 using UnityEngine;
 
@@ -18,14 +20,120 @@ public class LevelData
     } 
 }
 
-public class SaveData
+[System.Serializable]
+public class SaveData : ISerializable
 {
+    public static string SaveFormatVersion = "0.1";
+
+    // Determines the format version used for this save file
+    // Save files with missmatching version strings will not be loaded by the game
+    public string formatVersion;
+
     public LevelDescriptor CurrentLevel;
     public Dictionary<LevelDescriptor, LevelData> levelData;
 
     public SaveData()
     {
         levelData = new Dictionary<LevelDescriptor, LevelData>();
+    }
+
+    public void SaveToFile(string filePath)
+    {
+        string fullPath = Application.persistentDataPath + "/" + filePath;
+
+        // Set save format version before writing to file
+        formatVersion = SaveFormatVersion;
+
+        FileStream dataStream = new FileStream(fullPath, FileMode.Create);
+        BinaryFormatter formatter = new BinaryFormatter();
+        formatter.Serialize(dataStream, this);
+
+        dataStream.Close();
+    }
+
+    // Returns save file object loaded from file or a new SaveData object if file was not found
+    public static SaveData LoadSaveFile(string filePath)
+    {
+        string fullPath = Application.persistentDataPath + "/" + filePath;
+
+        SaveData ret = new SaveData();
+
+        try {
+            FileStream dataStream = new FileStream(fullPath, FileMode.Open);
+            BinaryFormatter formatter = new BinaryFormatter();
+            ret = formatter.Deserialize(dataStream) as SaveData;
+
+            if(ret.formatVersion != SaveData.SaveFormatVersion)
+            {
+                ret = new SaveData();
+            }
+
+            dataStream.Close();
+        }catch(FileNotFoundException) 
+        {
+            Debug.Log("Creating new save file");
+        }catch(System.Exception)
+        {
+            Debug.Log("Corrupted save file");
+        }
+
+        return ret;
+    }
+
+    protected SaveData(SerializationInfo info, StreamingContext context)
+    {
+        // formatVersion
+        formatVersion = info.GetValue("formatVersion", typeof(string)) as string;
+
+        //CurrentLevel
+        string currentLevelString = info.GetValue("currentLevel", typeof(string)) as string;
+        if(currentLevelString == "")
+        {
+            CurrentLevel = null;
+        }else
+        {
+            CurrentLevel = GameManager.Instance.Levels.Find(x => x.scenePath == currentLevelString);
+            if(CurrentLevel == null)
+            {
+                throw new System.Exception("Could not find CurrentLevel during deserialization");
+            }
+        }
+
+        // levelData
+        levelData = new Dictionary<LevelDescriptor, LevelData>();
+        var deserializedLevelData = info.GetValue("levelData", typeof(List<System.Tuple<string, LevelData>>)) as List<System.Tuple<string, LevelData>>;
+        foreach(var entry in deserializedLevelData)
+        {
+            LevelDescriptor levelDescriptor = GameManager.Instance.Levels.Find(x => x.scenePath == entry.Item1);
+            if(levelDescriptor == null)
+            {
+                throw new System.Exception("Could not find LevelDescriptor for: " + entry.Item1 + " during deserialization");
+            }
+            levelData.Add(levelDescriptor, entry.Item2);
+        }
+    }
+
+    public void GetObjectData(SerializationInfo info, StreamingContext context)
+    {
+        // formatVersion
+        info.AddValue("formatVersion", formatVersion, typeof(string));
+
+        // CurrentLevel
+        if(CurrentLevel != null)
+        {
+            info.AddValue("currentLevel", CurrentLevel.scenePath, typeof(string));
+        }else
+        {
+            info.AddValue("currentLevel", "", typeof(string));
+        }
+
+        // levelData
+        var serializableLevelData = new List<System.Tuple<string, LevelData>>();
+        foreach(var entry in levelData)
+        {
+            serializableLevelData.Add(new System.Tuple<string, LevelData>(entry.Key.scenePath, entry.Value));
+        }
+        info.AddValue("levelData", serializableLevelData, typeof(List<System.Tuple<string, LevelData>>));
     }
 
     public override string ToString()

--- a/Assets/Scripts/SaveData.cs
+++ b/Assets/Scripts/SaveData.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.Serialization.Formatters.Binary;
 using UnityEngine;
 
 [System.Serializable]

--- a/Assets/Scripts/UI/LevelsMenu.cs
+++ b/Assets/Scripts/UI/LevelsMenu.cs
@@ -29,6 +29,15 @@ public class LevelsMenu : MonoBehaviour
             levelListItem.transform.Find("Thumbnail").GetComponent<Image>().sprite = level.thumbnail;
             levelListItem.transform.Find("LevelName").GetComponentInChildren<Text>().text = level.levelName;
 
+            if(!GameManager.Instance.PlayerProgress.levelData.ContainsKey(level))
+            {
+                levelListItem.transform.Find("LevelName").GetComponent<Button>().interactable = false;
+
+                // dim item to display as 'unavailable'
+                levelListItem.transform.Find("LevelName").GetComponentInChildren<Text>().color *= 0.6f;
+                levelListItem.transform.Find("Thumbnail").GetComponent<Image>().color *= 0.6f;
+            }
+
             levelListItem.transform.Find("LevelName").GetComponent<Button>().onClick.AddListener(() => {
                 OnLevelSelect(level);
             });

--- a/Assets/Scripts/UI/MainMenu.cs
+++ b/Assets/Scripts/UI/MainMenu.cs
@@ -17,6 +17,11 @@ public class MainMenu : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
+        Repaint();
+    }
+
+    private void Repaint()
+    {
         if(GameManager.Instance.PlayerProgress.CurrentLevel != null)
         {
             m_playButton.GetComponentInChildren<Text>().text = "CONTINUE";
@@ -34,6 +39,13 @@ public class MainMenu : MonoBehaviour
     public void OnClickLevels()
     {
         GameManager.Instance.LevelSelect();
+    }
+
+    public void OnClickResetSave()
+    {
+        GameManager.Instance.ResetSaveData();
+
+        Repaint();
     }
 
     public void OnClickQuit()

--- a/Assets/Scripts/UI/MainMenu.cs
+++ b/Assets/Scripts/UI/MainMenu.cs
@@ -17,7 +17,7 @@ public class MainMenu : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        if(GameManager.Instance.PlayerProgress != null)
+        if(GameManager.Instance.PlayerProgress.CurrentLevel != null)
         {
             m_playButton.GetComponentInChildren<Text>().text = "CONTINUE";
         }else

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b9de969c523bc5ff60817807f9d5f36e3b982b8d8fe40ead6891046eb483ea38
-size 19535
+oid sha256:b9ee54def54d3c8cee92c7c34bd273b6646c81f7f07a13a0041a0be814ee2807
+size 19579


### PR DESCRIPTION
Players progress is now saved in a file in the applications persistent storage directory.
Progress can be reset in the MainMenu with the `Reset Save Data` button.
A player can only select a level in LevelSelect which has already unlocked (aka visited at least once).